### PR TITLE
Added RedHat to _reboot_needs_restarting_command variable

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,6 +10,7 @@ reboot_requirements: "{{ _reboot_requirements[ansible_distribution] | default(_r
 _reboot_needs_restarting_command:
   CentOS: needs-restarting -r
   Fedora: needs-restarting
+  RedHat: needs-restarting -r
 
 reboot_needs_restarting_command: "{{ _reboot_needs_restarting_command[ansible_distribution] }}"
 


### PR DESCRIPTION
---
name: Pull request to fix bug with RedHat hosts.
---

**Describe the change**
The role is currently erroring on RedHat hosts due to a missing entry in the _reboot_needs_restarting_command dictionary.  After adding this single line, it works correctly.

Ansible error:
TASK [robertdebock.reboot : see if a reboot is required for rhel] ****************************************************fatal: [host]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'RedHat'\n\nThe error appears to be in '/home/username/.ansible/roles/robertdebock.reboot/tasks/main.yml': line 21, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: see if a reboot is required for rhel\n  ^ here\n"}

**Testing**
This has been tested successfully with RHEL 7.