### PR TITLE
Fix broken role and clean up the logic

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,59 +8,45 @@
   until: reboot_install_requirements is succeeded
   retries: 3
 
-- name: check for needs-restarting for rhel
-  stat:
-    path: /usr/bin/needs-restarting
-  register: reboot_check_for_needs_restarting_for_rhel
-
-- name: check for needs-restarting for debian
-  stat:
-    path: /var/run/needs-restarting
-  register: reboot_check_for_needs_restarting_for_debian
-
-- name: see if a reboot is required for rhel
-  command: "{{ reboot_needs_restarting_command }}"
-  check_mode: no
-  register: reboot_needsrestarting
-  changed_when:
-    - reboot_needsrestarting.rc != 0
-  failed_when:
-    - reboot_needsrestarting.rc != 1
-    - reboot_needsrestarting.rc != 0
-  when:
+- when:
     - ansible_virtualization_type != "docker"
     - ansible_virtualization_type != "container"
-    - reboot_check_for_needs_restarting_for_rhel.stat.exists
-    - not reboot_always | bool
+    - ansible_os_family == "RedHat"
+  block:
+    - name: check for needs-restarting executable (rhel)
+      stat:
+        path: /usr/bin/needs-restarting
+      register: reboot_rhel_needs_restarting_executable
 
-- name: see if a reboot is required for debian
-  command: "{{ reboot_needs_restarting_command }}"
-  check_mode: no
-  register: reboot_debian_needrestarting
-  changed_when: no
-  when:
+    - name: see if a reboot is required (rhel)
+      command: needs-restarting -r
+      check_mode: no
+      register: reboot_rhel_needsrestarting
+      changed_when: reboot_rhel_needsrestarting.rc == 1
+      failed_when: reboot_rhel_needsrestarting.rc not in [0,1]
+      when: reboot_rhel_needs_restarting_executable.stat.exists
+
+- when:
     - ansible_virtualization_type != "docker"
     - ansible_virtualization_type != "container"
     - ansible_os_family == "Debian"
+  block:
+    - name: check for needrestart executable (debian)
+      stat:
+        path: /usr/sbin/needrestart
+      register: reboot_debian_needsrestart_executable
 
-- name: reboot the machine
-  shell: "(sleep {{ reboot_delay }} && {{ reboot_command }} &)"
-  async: 1
-  poll: 0
-  ignore_errors: yes
-  when:
+    - name: see if a reboot is required (debian)
+      command: needrestart -b
+      check_mode: no
+      register: reboot_debian_needrestarting
+      changed_when: "'NEEDRESTART-KSTA: 3' in reboot_debian_needrestarting.stdout_lines"
+      when: reboot_debian_needsrestart_executable.stat.exists
+
+- when:
     - ansible_virtualization_type != "docker"
     - ansible_virtualization_type != "container"
-    - reboot_always | bool or
-      ((reboot_check_for_needs_restarting_for_rhel.stat.exists and
-      reboot_needsrestarting.rc == 1) or
-      reboot_check_for_needs_restarting_for_debian.stat.exists) or
-      ("'NEEDRESTART-KSTA' in reboot_debian_needrestarting.stdout" and
-      "'3' in reboot_debian_needrestarting.stdout")
-  notify:
-    - 1 wait for the start of reboot
-    - 2 wait for the machine to be up
-    - 3 gather facts after reboot
-
-- name: flush handlers
-  meta: flush_handlers
+    - (reboot_always | bool)
+      or (reboot_rhel_needsrestarting.changed | default(false))
+      or (reboot_debian_needrestarting.changed | default(false))
+  include_tasks: reboot.yml

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -1,5 +1,13 @@
 ---
-# handlers file for reboot
+- name: flush notified handlers
+  meta: flush_handlers
+
+- name: reboot the machine
+  shell: "(sleep {{ reboot_delay }} && {{ reboot_command }} &)"
+  async: 1
+  poll: 0
+  ignore_errors: yes
+
 - name: 1 wait for the start of reboot
   pause:
     seconds: "{{ reboot_delay }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,13 +9,6 @@ _reboot_requirements:
 
 reboot_requirements: "{{ _reboot_requirements[ansible_distribution] | default(_reboot_requirements['default']) }}"
 
-_reboot_needs_restarting_command:
-  Debian: /usr/sbin/needrestart -b
-  RedHat-7: needs-restarting -r
-  RedHat: needs-restarting
-
-reboot_needs_restarting_command: "{{ _reboot_needs_restarting_command[ansible_os_family ~ '-' ~ ansible_distribution_major_version] | default(_reboot_needs_restarting_command[ansible_os_family]) }}"
-
 _reboot_command:
   default: shutdown -r now {{ reboot_message }}
   Alpine: reboot


### PR DESCRIPTION
---
name: Pull request
about: Fix and clean up the role

---

**Describe the change**
The main purpose of the role is to restart the server in case a restart is a restart is required, but unfortunately it fails to due so and always restarts any system. The reason is a wrong restart condition. When I looked through the role I couldn't help myself and rewrite most of it. Here are my reasons why:

- The condition `("'NEEDRESTART-KSTA' in debian_needrestarting.stdout" and "'3' in debian_needrestarting.stdout")` is basically `(str|length>0 and str|length>0)` which is always true. Even if the two conditions weren't treated as strings, they would evaluate to true most definitely all the time, because 'NEEDRESTART-KSTA' is always in the output and so is probably '3' somewhere. I guess you wanted to check `'NEEDRESTART-KSTA: 3' in debian_needrestarting.stdout`
- What is the reason to use handlers to perform the restart? Yes, it is reasonable to execute any notified handlers prior reboot, but performing the actual reboot can be perfectly be put in the main body of the role.
- I don't know what the file check on Debian for `/var/run/needs-restarting` is supposed to do, at least I couldn't find any information about such a file to be created. Maybe you meant `/var/run/reboot-required` ? However, checking reboot condition using `needrestart` seems to be the better choice anyway.
- Overall the readability lacks a bit, so I wanted to clean up
