### PR TITLE
Replace "wait_for" by "wait_for_connection" module

### DIFF
--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -14,7 +14,7 @@
     seconds: "{{ reboot_delay }}"
 
 - name: 2 wait for the machine to be up
-  ansible.builtin.wait_for:
+  ansible.builtin.wait_for_connection:
     delay: "{{ reboot_up_delay }}"
 
 - name: 3 gather facts after reboot


### PR DESCRIPTION
---
Replace "wait_for" by "wait_for_connection" module
---
**Description**
In the current implementation I regularly get the following error message:

    TASK [robertdebock.reboot : 2 wait for the machine to be up] *****************************************
    fatal: [my-host]: UNREACHABLE! => changed=false 
      msg: 'Data could not be sent to remote host "10.0.0.1". Make sure this host can be reached over ssh: '
      unreachable: true

It seems that the configured delay is not always considered. After a bit of research and testing I found out that the module "wait-for-connection" is better suited for this specific use case. 